### PR TITLE
shell-quote xtrace output

### DIFF
--- a/src/alias.c
+++ b/src/alias.c
@@ -202,7 +202,7 @@ freealias(struct alias *ap) {
 
 void
 printalias(const struct alias *ap) {
-	out1fmt("%s=%s\n", ap->name, single_quote(ap->val));
+	out1fmt("%s=%s\n", ap->name, single_quote(ap->val, 0));
 }
 
 STATIC struct alias **

--- a/src/mystring.c
+++ b/src/mystring.c
@@ -57,6 +57,7 @@
 #include "memalloc.h"
 #include "parser.h"
 #include "system.h"
+#include "token_vars.h"
 
 
 char nullstr[1];		/* zero length string */
@@ -188,12 +189,19 @@ is_number(const char *p)
 
 /*
  * Produce a possibly single quoted string suitable as input to the shell.
- * The return string is allocated on the stack.
+ * If 'conditional' is nonzero, quoting is only done if the string contains
+ * non-shellsafe characters, or is identical to a shell keyword (reserved
+ * word); if it is zero, quoting is always done.
+ * If quoting was done, the return string is allocated on the stack,
+ * otherwise a pointer to the original string is returned.
  */
 
 char *
-single_quote(const char *s) {
+single_quote(const char *s, int conditional) {
 	char *p;
+
+	if (conditional && *s != '\0' && s[strspn(s, SHELLSAFECHARS)] == '\0' && ! findkwd(s))
+		return (char *)s;
 
 	STARTSTACKSTR(p);
 

--- a/src/mystring.h
+++ b/src/mystring.h
@@ -56,10 +56,13 @@ intmax_t atomax(const char *, const char **, int);
 intmax_t atomax10(const char *);
 int number(const char *);
 int is_number(const char *);
-char *single_quote(const char *);
+char *single_quote(const char *, int);
 char *sstrdup(const char *);
 int pstrcmp(const void *, const void *);
 const char *const *findstring(const char *, const char *const *, size_t);
 
 #define equal(s1, s2)	(strcmp(s1, s2) == 0)
 #define scopy(s1, s2)	((void)strcpy(s2, s1))
+
+/* Characters that don't need quoting before re-entry into the shell */
+#define SHELLSAFECHARS "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz%+,./:@_^-"

--- a/src/trap.c
+++ b/src/trap.c
@@ -111,12 +111,12 @@ trapcmd(int argc, char **argv)
 				if (signo < signal_names_length && signal_names[signo])
 					out1fmt(
 						"trap -- %s %s\n",
-						single_quote(trap[signo]),
+						single_quote(trap[signo], 0),
 						signal_names[signo]);
 				else
 					out1fmt(
 						"trap -- %s %d\n",
-						single_quote(trap[signo]),
+						single_quote(trap[signo], 0),
 						signo);
 			}
 		}

--- a/src/var.c
+++ b/src/var.c
@@ -428,7 +428,7 @@ showvars(const char *prefix, int on, int off)
 		p = strchrnul(*ep, '=');
 		q = nullstr;
 		if (*p)
-			q = single_quote(++p);
+			q = single_quote(++p, 0);
 
 		out1fmt("%s%s%.*s%s\n", prefix, sep, (int)(p - *ep), *ep, q);
 	}


### PR DESCRIPTION
The xtrace (set -x) output in gwsh is a bit of a pain, because
arguments containing whitespace aren't quoted. This can it
impossible to tell which bit belongs to which argument:

$ gwsh -c 'set -x; printf "%s\n" one "two three" four'
+ printf %s\n one two three four
one
two three
four

Another disadvantage is you cannot simply copy and paste the
commands from this xtrace output to repeat them for debugging
purposes.

This commit introduces shell-quoting of xtrace arguments that
contain non-shell-safe characters or are identical to reserved
words.

A parameter is added to single_quote() indicating whether quoting
should be unconditional (0) or conditional upon the string
containing characters that are not shell-safe (1). This leaves the
unconditional quoting in the output of commands like 'trap' and
'set' unchanged while avoiding excessive quoting in xtrace output.

Shell-safe characters are defined as this set:
0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz%+,./:@_^-

Quoting of assignments needs to be handled specially; in order for
the output to be suitable for re-entry into the shell, only the
part after the "=" must be quoted. For this purpose, eprintlist()
was split in into two functions, eprintvarlist() to print the
variable assignments and eprintarglist() to print the rest.